### PR TITLE
address card background issue

### DIFF
--- a/index.css
+++ b/index.css
@@ -15,10 +15,6 @@ body {
   color: var(--vue-blue);
 }
 
-.card-front i {
-  font-size: 3.5rem;
-}
-
 #game {
   width: 100%;
   display: flex;
@@ -64,8 +60,20 @@ body {
   position: absolute;
   font-size: 3rem;
   border: 5px solid white;
-  background: var(--vue-green);
   backface-visibility: hidden;
+}
+
+.card-front {
+  background: var(--vue-green);
+}
+
+.card-back {
+  background: var(--vue-blue);
+  color: var(--vue-green);
+}
+
+.card-front i {
+  font-size: 3.5rem;
 }
 
 .flip{


### PR DESCRIPTION
Changed the backside of the cards to have the blue primary background color with the green text color. This will allow for easier differentiation between which cards are flipped and which are not.